### PR TITLE
Update S3 client configuration for environment variables

### DIFF
--- a/src/utils/s3Client.ts
+++ b/src/utils/s3Client.ts
@@ -7,9 +7,9 @@ import {
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 
 // S3 Configuration
-const S3_ENDPOINT = import.meta.env.S3_ENDPOINT;
-const S3_ACCESS_KEY = import.meta.env.S3_ACCESS_KEY;
-const S3_SECRET_KEY = import.meta.env.S3_SECRET_KEY;
+const S3_ENDPOINT = import.meta.env.VITE_S3_ENDPOINT;
+const S3_ACCESS_KEY = import.meta.env.VITE_S3_ACCESS_KEY;
+const S3_SECRET_KEY = import.meta.env.VITE_S3_SECRET_KEY;
 const BUCKET_NAME = "bosuutap"; // Updated to the correct bucket name
 
 // Create S3 client

--- a/src/utils/s3Client.ts
+++ b/src/utils/s3Client.ts
@@ -7,9 +7,9 @@ import {
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 
 // S3 Configuration
-const S3_ENDPOINT = process.env.S3_ENDPOINT;
-const S3_ACCESS_KEY = process.env.S3_ACCESS_KEY;
-const S3_SECRET_KEY = process.env.S3_SECRET_KEY;
+const S3_ENDPOINT = import.meta.env.S3_ENDPOINT;
+const S3_ACCESS_KEY = import.meta.env.S3_ACCESS_KEY;
+const S3_SECRET_KEY = import.meta.env.S3_SECRET_KEY;
 const BUCKET_NAME = "bosuutap"; // Updated to the correct bucket name
 
 // Create S3 client


### PR DESCRIPTION
Refactor S3 client configuration to utilize `import.meta.env` with a `VITE` prefix for environment variables. This change enhances compatibility with Vite-based projects.